### PR TITLE
Fix no reverse match error

### DIFF
--- a/auctions/urls.py
+++ b/auctions/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('login/', views.login_view, name='login'),
     path('logout/', views.logout_view, name='logout'),
     path('register/', views.register_view, name='register'),
+    path('history/', views.history, name='history'),
     path('items/new/', views.item_create, name='item_create'),
     path('items/<int:pk>/', views.item_detail, name='item_detail'),
     path('items/<int:pk>/bid/', views.place_bid, name='place_bid'),

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -400,3 +400,15 @@ def settle(request: HttpRequest, pk: int) -> HttpResponse:
     messages.success(request, 'Winner charged automatically and order created.')
     return redirect('item_detail', pk=pk)
 
+
+@login_required
+def history(request: HttpRequest) -> HttpResponse:
+    """Show the authenticated user's activity history."""
+    orders = Order.objects.filter(buyer=request.user).order_by('-created_at')
+    payments = Payment.objects.filter(buyer=request.user).order_by('-created_at')
+    bids = Bid.objects.filter(bidder=request.user).select_related('item').order_by('-created_at')
+    return render(request, 'auctions/history.html', {
+        'orders': orders,
+        'payments': payments,
+        'bids': bids,
+    })

--- a/templates/auctions/history.html
+++ b/templates/auctions/history.html
@@ -1,0 +1,41 @@
+{% extends 'auctions/base.html' %}
+{% block title %}History{% endblock %}
+{% block content %}
+<h1 class="h4 mb-3">Your History</h1>
+
+<h2 class="h6 mt-4">Bids</h2>
+<ul class="list-group mb-3">
+  {% for bid in bids %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ bid.item.title }} — ₹{{ bid.amount }} <small class="text-muted">on {{ bid.created_at|date:"M d, Y H:i" }}</small></span>
+    <a class="btn btn-sm btn-outline-primary" href="{% url 'item_detail' bid.item_id %}">View</a>
+  </li>
+  {% empty %}
+  <li class="list-group-item">No bids yet.</li>
+  {% endfor %}
+</ul>
+
+<h2 class="h6 mt-4">Payments</h2>
+<ul class="list-group mb-3">
+  {% for p in payments %}
+  <li class="list-group-item">
+    ₹{{ p.amount }} — {{ p.purpose|title }} — <span class="badge text-bg-secondary">{{ p.status }}</span>
+    <small class="text-muted ms-2">{{ p.created_at|date:"M d, Y H:i" }}</small>
+  </li>
+  {% empty %}
+  <li class="list-group-item">No payments yet.</li>
+  {% endfor %}
+</ul>
+
+<h2 class="h6 mt-4">Orders</h2>
+<ul class="list-group">
+  {% for o in orders %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ o.item.title }} — ₹{{ o.amount }} <span class="badge text-bg-info">{{ o.status }}</span></span>
+    <a class="btn btn-sm btn-outline-primary" href="{% url 'item_detail' o.item_id %}">Item</a>
+  </li>
+  {% empty %}
+  <li class="list-group-item">No orders yet.</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
Add `history` view, URL, and template to resolve `NoReverseMatch` error.

The `NoReverseMatch` error occurred because the base template referenced a URL named 'history' that was not defined in `auctions/urls.py`. This PR introduces the necessary view, URL pattern, and a basic template to display user activity history, thus fixing the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2382bfa7-aac7-452b-91bd-c7be23e9fe4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2382bfa7-aac7-452b-91bd-c7be23e9fe4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

